### PR TITLE
fix: document correct dev port

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pnpm dev
 bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3001](http://localhost:3001) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -3,12 +3,18 @@ import { useEffect, useState } from "react";
 import { getTodos } from "@/lib/api";
 import TodoItem from "./TodoItem";
 
+interface Todo {
+  id: number;
+  task: string;
+  completed: boolean;
+}
+
 export default function TodoList() {
-  const [todos, setTodos] = useState<any[]>([]);
+  const [todos, setTodos] = useState<Todo[]>([]);
 
   const loadTodos = async () => {
     try {
-      const data = await getTodos();
+      const data: Todo[] = await getTodos();
       setTodos(data);
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
## Summary
- document dev server running on port 3001
- type Todo list state to satisfy lint rules

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899238adf208332b85719aae88a4bb7